### PR TITLE
Change all APIs that returns `Result<String, Utf8Error>` to either ret `MagickCString` or `&'static CStr` to archive zero-copy and enable users to handle non utf-8 string

### DIFF
--- a/graphicsmagick/src/lib.rs
+++ b/graphicsmagick/src/lib.rs
@@ -15,5 +15,5 @@ pub mod wand;
 
 pub use crate::{
     error::{Error, Result},
-    utils::{has_initialized, initialize, max_rgb, MaxRGB},
+    utils::{has_initialized, initialize, max_rgb, MagickCString, MaxRGB},
 };

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -84,18 +84,18 @@ impl Drop for MagickAlloc {
     }
 }
 
-pub(crate) fn c_str_to_string(c: *const c_char) -> Result<String, FromUtf8Error> {
+pub(crate) unsafe fn c_str_to_string(c: *const c_char) -> Result<String, FromUtf8Error> {
     // Use MagickAlloc to ensure c is free on unwinding.
     let _magick_cstring = MagickAlloc(c as *const c_void);
 
     c_str_to_string_no_free(c)
 }
 
-pub(crate) fn c_str_to_string_no_free(c: *const c_char) -> Result<String, FromUtf8Error> {
+pub(crate) unsafe fn c_str_to_string_no_free(c: *const c_char) -> Result<String, FromUtf8Error> {
     if c.is_null() {
         Ok("".to_string())
     } else {
-        let cstr = unsafe { CStr::from_ptr(c) };
+        let cstr = CStr::from_ptr(c);
         let bytes = cstr.to_bytes().to_vec();
 
         String::from_utf8(bytes)

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -146,3 +146,13 @@ impl MagickCString {
         String::from_utf8_lossy(self.as_cstr().to_bytes())
     }
 }
+
+pub(crate) trait CStrExt {
+    unsafe fn from_ptr_checked_on_debug<'a>(ptr: *const c_char) -> &'a CStr {
+        debug_assert!(!ptr.is_null());
+
+        CStr::from_ptr(ptr)
+    }
+}
+
+impl CStrExt for CStr {}

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -5,7 +5,6 @@ use std::{
     os::raw::{c_char, c_double, c_uint, c_void},
     ptr::{null, NonNull},
     str::Utf8Error,
-    string::FromUtf8Error,
     sync::Once,
     thread,
 };
@@ -90,24 +89,6 @@ impl Drop for MagickAlloc {
         unsafe {
             graphicsmagick_sys::MagickFree(self.0.as_ptr());
         }
-    }
-}
-
-pub(crate) unsafe fn c_str_to_string(c: *const c_char) -> Result<String, FromUtf8Error> {
-    // Use MagickAlloc to ensure c is free on unwinding.
-    let _magick_cstring = MagickAlloc::new(c as *mut c_void);
-
-    c_str_to_string_no_free(c)
-}
-
-pub(crate) unsafe fn c_str_to_string_no_free(c: *const c_char) -> Result<String, FromUtf8Error> {
-    if c.is_null() {
-        Ok("".to_string())
-    } else {
-        let cstr = CStr::from_ptr(c);
-        let bytes = cstr.to_bytes().to_vec();
-
-        String::from_utf8(bytes)
     }
 }
 

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -121,7 +121,7 @@ impl MagickCString {
     }
 
     /// Convert [`MagickCString`] to [`CStr`].
-    pub fn as_cstr(&self) -> &CStr {
+    pub fn as_c_str(&self) -> &CStr {
         self.0
             .as_ref()
             .map(|alloc| unsafe { CStr::from_ptr(alloc.as_ptr() as *const c_char) })
@@ -130,7 +130,7 @@ impl MagickCString {
 
     /// Convert [`MagickCString`] to [`str`].
     pub fn to_str(&self) -> Result<&str, Utf8Error> {
-        self.as_cstr().to_str()
+        self.as_c_str().to_str()
     }
 
     /// Convert [`MagickCString`] to utf-8 string, including
@@ -143,7 +143,7 @@ impl MagickCString {
     /// are replaced with [`std::char::REPLACEMENT_CHARACTER`],
     /// which looks like this: "�"
     pub fn to_str_lossy(&self) -> Cow<'_, str> {
-        String::from_utf8_lossy(self.as_cstr().to_bytes())
+        String::from_utf8_lossy(self.as_c_str().to_bytes())
     }
 }
 

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -63,7 +63,11 @@ pub fn max_rgb<T: MaxRGB>() -> T {
 }
 
 pub(crate) fn str_to_c_string(s: &str) -> CString {
-    let buf = s.bytes().chain(0..1).collect::<Vec<_>>();
+    let buf = s.bytes().collect::<Vec<_>>();
+    // from_vec_unchecked appends the trailing '\0'
+    //
+    // Safety:
+    // s is a utf-8 str, so it cannot contains '\0'.
     unsafe { CString::from_vec_unchecked(buf) }
 }
 

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -120,15 +120,25 @@ impl MagickCString {
         MagickAlloc::new(c as *mut c_void).map(Self)
     }
 
-    /// Convert the result to `CStr`.
+    /// Convert [`MagickCString`] to [`CStr`].
     pub fn as_cstr(&self) -> &CStr {
         unsafe { CStr::from_ptr(self.0.as_ptr() as *const c_char) }
     }
 
+    /// Convert [`MagickCString`] to [`str`].
     pub fn to_str(&self) -> Result<&str, Utf8Error> {
         self.as_cstr().to_str()
     }
 
+    /// Convert [`MagickCString`] to utf-8 string, including
+    /// non utf-8 characters.
+    ///
+    /// If all characters are valid utf-8 character, then
+    /// `Cow::Borrowed` is returned.
+    ///
+    /// Otherwise, `Cow::Owned` is returned where any invalid UTF-8 sequences
+    /// are replaced with [`std::char::REPLACEMENT_CHARACTER`],
+    /// which looks like this: "�"
     pub fn to_str_lossy(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(self.as_cstr().to_bytes())
     }

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -11,6 +11,7 @@ use std::{
 static HAS_INITIALIZED: Once = Once::new();
 
 /// Wrapper of `graphicsmagick_sys::InitializeMagick`, call it before any `graphicsmagick` action.
+/// Must be call in the main thread.
 pub fn initialize() {
     HAS_INITIALIZED.call_once(|| {
         assert_eq!(

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -14,7 +14,7 @@ use graphicsmagick_sys::*;
 use std::{
     os::raw::{c_double, c_uint, c_ulong},
     ptr::null_mut,
-    str::Utf8Error,
+    string::FromUtf8Error,
 };
 
 /// Wrapper of `graphicsmagick_sys::DrawingWand`.
@@ -152,7 +152,7 @@ impl DrawingWand {
     ///
     /// must be deallocated by the user when it is no longer needed.
     ///
-    pub fn get_clip_path(&self) -> Result<String, Utf8Error> {
+    pub fn get_clip_path(&self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickDrawGetClipPath(self.wand) };
         c_str_to_string(c)
     }
@@ -338,7 +338,7 @@ impl DrawingWand {
     ///
     /// when no longer needed.
     ///
-    pub fn get_font(&self) -> Result<String, Utf8Error> {
+    pub fn get_font(&self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickDrawGetFont(self.wand) };
         c_str_to_string(c)
     }
@@ -361,7 +361,7 @@ impl DrawingWand {
     ///
     /// The value returned must be freed by the user when it is no longer needed.
     ///
-    pub fn get_font_family(&self) -> Result<String, Utf8Error> {
+    pub fn get_font_family(&self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickDrawGetFontFamily(self.wand) };
         c_str_to_string(c)
     }
@@ -1534,7 +1534,7 @@ impl DrawingWand {
     ///
     /// once it is no longer required.
     ///
-    pub fn get_text_encoding(&self) -> Result<String, Utf8Error> {
+    pub fn get_text_encoding(&self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickDrawGetTextEncoding(self.wand) };
         c_str_to_string(c)
     }

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -153,8 +153,7 @@ impl DrawingWand {
     /// must be deallocated by the user when it is no longer needed.
     ///
     pub fn get_clip_path(&self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickDrawGetClipPath(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickDrawGetClipPath(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsetclippath>
@@ -339,8 +338,7 @@ impl DrawingWand {
     /// when no longer needed.
     ///
     pub fn get_font(&self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickDrawGetFont(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickDrawGetFont(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsetfont>
@@ -362,8 +360,7 @@ impl DrawingWand {
     /// The value returned must be freed by the user when it is no longer needed.
     ///
     pub fn get_font_family(&self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickDrawGetFontFamily(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickDrawGetFontFamily(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsetfontfamily>
@@ -1535,8 +1532,7 @@ impl DrawingWand {
     /// once it is no longer required.
     ///
     pub fn get_text_encoding(&self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickDrawGetTextEncoding(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickDrawGetTextEncoding(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsettextencoding>

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -152,7 +152,7 @@ impl DrawingWand {
     ///
     /// must be deallocated by the user when it is no longer needed.
     ///
-    pub fn get_clip_path(&self) -> Option<MagickCString> {
+    pub fn get_clip_path(&self) -> MagickCString {
         unsafe { MagickCString::new(MagickDrawGetClipPath(self.wand)) }
     }
 
@@ -337,7 +337,7 @@ impl DrawingWand {
     ///
     /// when no longer needed.
     ///
-    pub fn get_font(&self) -> Option<MagickCString> {
+    pub fn get_font(&self) -> MagickCString {
         unsafe { MagickCString::new(MagickDrawGetFont(self.wand)) }
     }
 
@@ -359,7 +359,7 @@ impl DrawingWand {
     ///
     /// The value returned must be freed by the user when it is no longer needed.
     ///
-    pub fn get_font_family(&self) -> Option<MagickCString> {
+    pub fn get_font_family(&self) -> MagickCString {
         unsafe { MagickCString::new(MagickDrawGetFontFamily(self.wand)) }
     }
 
@@ -1531,7 +1531,7 @@ impl DrawingWand {
     ///
     /// once it is no longer required.
     ///
-    pub fn get_text_encoding(&self) -> Option<MagickCString> {
+    pub fn get_text_encoding(&self) -> MagickCString {
         unsafe { MagickCString::new(MagickDrawGetTextEncoding(self.wand)) }
     }
 
@@ -1659,7 +1659,7 @@ mod tests {
     #[test]
     fn test_drawing_wand_get_clip_path() {
         let dw = new_logo_drawing_wand();
-        dw.get_clip_path().unwrap();
+        dw.get_clip_path().to_str().unwrap();
     }
 
     #[test]
@@ -1749,7 +1749,7 @@ mod tests {
     #[test]
     fn test_drawing_wand_get_font() {
         let dw = new_logo_drawing_wand();
-        dw.get_font().unwrap();
+        dw.get_font().to_str().unwrap();
     }
 
     #[test]
@@ -1761,7 +1761,7 @@ mod tests {
     #[test]
     fn test_drawing_wand_get_font_family() {
         let dw = new_logo_drawing_wand();
-        dw.get_font_family().unwrap();
+        dw.get_font_family().to_str().unwrap();
     }
 
     #[test]
@@ -2211,7 +2211,7 @@ mod tests {
     #[test]
     fn test_drawing_wand_get_text_encoding() {
         let dw = new_logo_drawing_wand();
-        dw.get_text_encoding().unwrap();
+        dw.get_text_encoding().to_str().unwrap();
     }
 
     #[test]

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -7,14 +7,14 @@ use crate::{
         ClipPathUnits, DecorationType, FillRule, GravityType, LineCap, LineJoin, PaintMethod,
         StretchType, StyleType,
     },
-    utils::{assert_initialized, c_arr_to_vec, c_str_to_string, str_to_c_string},
+    utils::{assert_initialized, c_arr_to_vec, str_to_c_string},
     wand::pixel::PixelWand,
+    MagickCString,
 };
 use graphicsmagick_sys::*;
 use std::{
     os::raw::{c_double, c_uint, c_ulong},
     ptr::null_mut,
-    string::FromUtf8Error,
 };
 
 /// Wrapper of `graphicsmagick_sys::DrawingWand`.
@@ -152,8 +152,8 @@ impl DrawingWand {
     ///
     /// must be deallocated by the user when it is no longer needed.
     ///
-    pub fn get_clip_path(&self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickDrawGetClipPath(self.wand)) }
+    pub fn get_clip_path(&self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickDrawGetClipPath(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsetclippath>
@@ -337,8 +337,8 @@ impl DrawingWand {
     ///
     /// when no longer needed.
     ///
-    pub fn get_font(&self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickDrawGetFont(self.wand)) }
+    pub fn get_font(&self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickDrawGetFont(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsetfont>
@@ -359,8 +359,8 @@ impl DrawingWand {
     ///
     /// The value returned must be freed by the user when it is no longer needed.
     ///
-    pub fn get_font_family(&self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickDrawGetFontFamily(self.wand)) }
+    pub fn get_font_family(&self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickDrawGetFontFamily(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsetfontfamily>
@@ -1531,8 +1531,8 @@ impl DrawingWand {
     ///
     /// once it is no longer required.
     ///
-    pub fn get_text_encoding(&self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickDrawGetTextEncoding(self.wand)) }
+    pub fn get_text_encoding(&self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickDrawGetTextEncoding(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsettextencoding>

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -625,7 +625,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// similar to the output of 'identify -verbose'.
     ///
-    pub fn describe_image(&mut self) -> Option<MagickCString> {
+    pub fn describe_image(&mut self) -> MagickCString {
         unsafe { MagickCString::new(MagickDescribeImage(self.wand)) }
     }
 
@@ -886,7 +886,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// NAME, VERSION, LIB_VERSION, COPYRIGHT, etc.
     ///
-    pub fn get_configure_info(&mut self, name: &str) -> Option<MagickCString> {
+    pub fn get_configure_info(&mut self, name: &str) -> MagickCString {
         let name = str_to_c_string(name);
         unsafe { MagickCString::new(MagickGetConfigureInfo(self.wand, name.as_ptr())) }
     }
@@ -903,7 +903,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetFilename() returns the filename associated with an image sequence.
     ///
-    pub fn get_filename(&self) -> Option<MagickCString> {
+    pub fn get_filename(&self) -> MagickCString {
         unsafe { MagickCString::new(MagickGetFilename(self.wand)) }
     }
 
@@ -928,7 +928,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetImageAttribute returns an image attribute as a string
     ///
-    pub fn get_image_attribute(&mut self, name: &str) -> Option<MagickCString> {
+    pub fn get_image_attribute(&mut self, name: &str) -> MagickCString {
         let name = str_to_c_string(name);
         unsafe { MagickCString::new(MagickGetImageAttribute(self.wand, name.as_ptr())) }
     }
@@ -1157,7 +1157,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// sequence.
     ///
-    pub fn get_image_filename(&mut self) -> Option<MagickCString> {
+    pub fn get_image_filename(&mut self) -> MagickCString {
         unsafe { MagickCString::new(MagickGetImageFilename(self.wand)) }
     }
 
@@ -1167,7 +1167,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// sequence.
     ///
-    pub fn get_image_format(&mut self) -> Option<MagickCString> {
+    pub fn get_image_format(&mut self) -> MagickCString {
         unsafe { MagickCString::new(MagickGetImageFormat(self.wand)) }
     }
 
@@ -1397,7 +1397,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetImageProfile() returns the named image profile.
     ///
-    pub fn get_image_profile(&mut self, name: &str) -> Option<MagickCString> {
+    pub fn get_image_profile(&mut self, name: &str) -> MagickCString {
         let mut length = 0;
         let name = str_to_c_string(name);
         unsafe {
@@ -1459,7 +1459,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// pixel stream.
     ///
-    pub fn get_image_signature(&mut self) -> Option<MagickCString> {
+    pub fn get_image_signature(&mut self) -> MagickCString {
         unsafe { MagickCString::new(MagickGetImageSignature(self.wand)) }
     }
 
@@ -2327,7 +2327,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickQueryFonts() returns any font that match the specified pattern.
     ///
-    pub fn query_fonts(pattern: &str) -> Option<Vec<Option<MagickCString>>> {
+    pub fn query_fonts(pattern: &str) -> Option<Vec<MagickCString>> {
         let pattern = str_to_c_string(pattern);
         let mut number_fonts = 0;
         let a = unsafe { MagickQueryFonts(pattern.as_ptr(), &mut number_fonts) };
@@ -2342,7 +2342,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// pattern.
     ///
-    pub fn query_formats(pattern: &str) -> Option<Vec<Option<MagickCString>>> {
+    pub fn query_formats(pattern: &str) -> Option<Vec<MagickCString>> {
         let pattern = str_to_c_string(pattern);
         let mut number_formats = 0;
         let a = unsafe { MagickQueryFormats(pattern.as_ptr(), &mut number_formats) };
@@ -2458,7 +2458,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickRemoveImageProfile() removes the named image profile and returns it.
     ///
-    pub fn remove_image_profile(&mut self, name: &str) -> Option<MagickCString> {
+    pub fn remove_image_profile(&mut self, name: &str) -> MagickCString {
         let name = str_to_c_string(name);
         let mut length = 0;
         unsafe {
@@ -3993,7 +3993,7 @@ mod tests {
     #[test]
     fn test_magick_wand_describe_image() {
         let mut mw = new_logo_magick_wand();
-        mw.describe_image().unwrap();
+        mw.describe_image().to_str().unwrap();
     }
 
     #[test]
@@ -4107,7 +4107,7 @@ mod tests {
     #[test]
     fn test_magick_wand_get_configure_info() {
         let mut mw = new_logo_magick_wand();
-        mw.get_configure_info("VERSION").unwrap();
+        mw.get_configure_info("VERSION").to_str().unwrap();
     }
 
     #[test]
@@ -4118,7 +4118,7 @@ mod tests {
     #[test]
     fn test_magick_wand_get_filename() {
         let mw = new_logo_magick_wand();
-        mw.get_filename().unwrap();
+        mw.get_filename().to_str().unwrap();
     }
 
     #[test]
@@ -4136,7 +4136,7 @@ mod tests {
     #[test]
     fn test_magick_wand_get_image_attribute() {
         let mut mw = new_logo_magick_wand();
-        mw.get_image_attribute("").unwrap();
+        mw.get_image_attribute("").to_str().unwrap();
     }
 
     #[test]
@@ -4240,13 +4240,13 @@ mod tests {
     #[test]
     fn test_magick_wand_get_image_filename() {
         let mut mw = new_logo_magick_wand();
-        mw.get_image_filename().unwrap();
+        mw.get_image_filename().to_str().unwrap();
     }
 
     #[test]
     fn test_magick_wand_get_image_format() {
         let mut mw = new_logo_magick_wand();
-        mw.get_image_format().unwrap();
+        mw.get_image_format().to_str().unwrap();
     }
 
     #[test]
@@ -4353,7 +4353,7 @@ mod tests {
     #[test]
     fn test_magick_wand_get_image_profile() {
         let mut mw = new_logo_magick_wand();
-        mw.get_image_profile("ICM").unwrap();
+        mw.get_image_profile("ICM").to_str().unwrap();
     }
 
     #[test]
@@ -4383,7 +4383,7 @@ mod tests {
     #[test]
     fn test_magick_wand_get_image_signature() {
         let mut mw = new_logo_magick_wand();
-        mw.get_image_signature().unwrap();
+        mw.get_image_signature().to_str().unwrap();
     }
 
     #[test]
@@ -4732,7 +4732,7 @@ mod tests {
     #[test]
     fn test_magick_wand_remove_image_profile() {
         let mut mw = new_logo_magick_wand();
-        mw.remove_image_profile("").unwrap();
+        mw.remove_image_profile("").to_str().unwrap();
     }
 
     #[test]

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -9,7 +9,7 @@ use crate::{
         ImageType, InterlaceType, MetricType, MontageMode, NoiseType, PreviewType, RenderingIntent,
         ResolutionType, ResourceType, VirtualPixelMethod,
     },
-    utils::{assert_initialized, c_arr_to_vec, str_to_c_string},
+    utils::{assert_initialized, c_arr_to_vec, str_to_c_string, CStrExt},
     wand::{DrawingWand, PixelWand},
     MagickCString,
 };
@@ -896,7 +896,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetCopyright() returns the ImageMagick API copyright as a string.
     ///
     pub fn get_copyright() -> &'static CStr {
-        unsafe { CStr::from_ptr(MagickGetCopyright()) }
+        unsafe { CStr::from_ptr_checked_on_debug(MagickGetCopyright()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetfilename>
@@ -912,7 +912,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetHomeURL() returns the ImageMagick home URL.
     ///
     pub fn get_home_url() -> &'static CStr {
-        unsafe { CStr::from_ptr(MagickGetHomeURL()) }
+        unsafe { CStr::from_ptr_checked_on_debug(MagickGetHomeURL()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimage>
@@ -1548,7 +1548,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetPackageName() returns the ImageMagick package name.
     ///
     pub fn get_package_name() -> &'static CStr {
-        unsafe { CStr::from_ptr(MagickGetPackageName()) }
+        unsafe { CStr::from_ptr_checked_on_debug(MagickGetPackageName()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetquantumdepth>
@@ -1558,7 +1558,7 @@ impl<'a> MagickWand<'a> {
     pub fn get_quantum_depth() -> (c_ulong, &'static CStr) {
         let mut depth = 0;
         let c = unsafe { MagickGetQuantumDepth(&mut depth) };
-        (depth, unsafe { CStr::from_ptr(c) })
+        (depth, unsafe { CStr::from_ptr_checked_on_debug(c) })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetreleasedate>
@@ -1566,7 +1566,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetReleaseDate() returns the ImageMagick release date.
     ///
     pub fn get_release_date() -> &'static CStr {
-        unsafe { CStr::from_ptr(MagickGetReleaseDate()) }
+        unsafe { CStr::from_ptr_checked_on_debug(MagickGetReleaseDate()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetresourcelimit>
@@ -1615,7 +1615,7 @@ impl<'a> MagickWand<'a> {
     pub fn get_version() -> (c_ulong, &'static CStr) {
         let mut version = 0;
         let c = unsafe { MagickGetVersion(&mut version) };
-        (version, unsafe { CStr::from_ptr(c) })
+        (version, unsafe { CStr::from_ptr_checked_on_debug(c) })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickhaldclutimage>

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -9,18 +9,17 @@ use crate::{
         ImageType, InterlaceType, MetricType, MontageMode, NoiseType, PreviewType, RenderingIntent,
         ResolutionType, ResourceType, VirtualPixelMethod,
     },
-    utils::{
-        assert_initialized, c_arr_to_vec, c_str_to_string, c_str_to_string_no_free, str_to_c_string,
-    },
+    utils::{assert_initialized, c_arr_to_vec, str_to_c_string},
     wand::{DrawingWand, PixelWand},
+    MagickCString,
 };
 use graphicsmagick_sys::*;
 use std::{
+    ffi::CStr,
     fmt,
     os::raw::{c_double, c_float, c_long, c_uchar, c_uint, c_ulong, c_ushort, c_void},
     ptr::null_mut,
     slice,
-    string::FromUtf8Error,
 };
 
 #[cfg(feature = "v1_3_26")]
@@ -626,8 +625,8 @@ impl<'a> MagickWand<'a> {
     ///
     /// similar to the output of 'identify -verbose'.
     ///
-    pub fn describe_image(&mut self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickDescribeImage(self.wand)) }
+    pub fn describe_image(&mut self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickDescribeImage(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickdespeckleimage>
@@ -887,33 +886,33 @@ impl<'a> MagickWand<'a> {
     ///
     /// NAME, VERSION, LIB_VERSION, COPYRIGHT, etc.
     ///
-    pub fn get_configure_info(&mut self, name: &str) -> Result<String, FromUtf8Error> {
+    pub fn get_configure_info(&mut self, name: &str) -> Option<MagickCString> {
         let name = str_to_c_string(name);
-        unsafe { c_str_to_string(MagickGetConfigureInfo(self.wand, name.as_ptr())) }
+        unsafe { MagickCString::new(MagickGetConfigureInfo(self.wand, name.as_ptr())) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetcopyright>
     ///
     /// MagickGetCopyright() returns the ImageMagick API copyright as a string.
     ///
-    pub fn get_copyright() -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string_no_free(MagickGetCopyright()) }
+    pub fn get_copyright() -> &'static CStr {
+        unsafe { CStr::from_ptr(MagickGetCopyright()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetfilename>
     ///
     /// MagickGetFilename() returns the filename associated with an image sequence.
     ///
-    pub fn get_filename(&self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickGetFilename(self.wand)) }
+    pub fn get_filename(&self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickGetFilename(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgethomeurl>
     ///
     /// MagickGetHomeURL() returns the ImageMagick home URL.
     ///
-    pub fn get_home_url() -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string_no_free(MagickGetHomeURL()) }
+    pub fn get_home_url() -> &'static CStr {
+        unsafe { CStr::from_ptr(MagickGetHomeURL()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimage>
@@ -929,9 +928,9 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetImageAttribute returns an image attribute as a string
     ///
-    pub fn get_image_attribute(&mut self, name: &str) -> Result<String, FromUtf8Error> {
+    pub fn get_image_attribute(&mut self, name: &str) -> Option<MagickCString> {
         let name = str_to_c_string(name);
-        unsafe { c_str_to_string(MagickGetImageAttribute(self.wand, name.as_ptr())) }
+        unsafe { MagickCString::new(MagickGetImageAttribute(self.wand, name.as_ptr())) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimagebackgroundcolor>
@@ -1158,8 +1157,8 @@ impl<'a> MagickWand<'a> {
     ///
     /// sequence.
     ///
-    pub fn get_image_filename(&mut self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickGetImageFilename(self.wand)) }
+    pub fn get_image_filename(&mut self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickGetImageFilename(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimageformat>
@@ -1168,8 +1167,8 @@ impl<'a> MagickWand<'a> {
     ///
     /// sequence.
     ///
-    pub fn get_image_format(&mut self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickGetImageFormat(self.wand)) }
+    pub fn get_image_format(&mut self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickGetImageFormat(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimagefuzz>
@@ -1398,11 +1397,11 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetImageProfile() returns the named image profile.
     ///
-    pub fn get_image_profile(&mut self, name: &str) -> Result<String, FromUtf8Error> {
+    pub fn get_image_profile(&mut self, name: &str) -> Option<MagickCString> {
         let mut length = 0;
         let name = str_to_c_string(name);
         unsafe {
-            c_str_to_string(MagickGetImageProfile(self.wand, name.as_ptr(), &mut length).cast())
+            MagickCString::new(MagickGetImageProfile(self.wand, name.as_ptr(), &mut length).cast())
         }
     }
 
@@ -1460,8 +1459,8 @@ impl<'a> MagickWand<'a> {
     ///
     /// pixel stream.
     ///
-    pub fn get_image_signature(&mut self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(MagickGetImageSignature(self.wand)) }
+    pub fn get_image_signature(&mut self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(MagickGetImageSignature(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimagesize>
@@ -1548,26 +1547,26 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetPackageName() returns the ImageMagick package name.
     ///
-    pub fn get_package_name() -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string_no_free(MagickGetPackageName()) }
+    pub fn get_package_name() -> &'static CStr {
+        unsafe { CStr::from_ptr(MagickGetPackageName()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetquantumdepth>
     ///
     /// MagickGetQuantumDepth() returns the ImageMagick quantum depth.
     ///
-    pub fn get_quantum_depth() -> (c_ulong, Result<String, FromUtf8Error>) {
+    pub fn get_quantum_depth() -> (c_ulong, &'static CStr) {
         let mut depth = 0;
         let c = unsafe { MagickGetQuantumDepth(&mut depth) };
-        (depth, unsafe { c_str_to_string_no_free(c) })
+        (depth, unsafe { CStr::from_ptr(c) })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetreleasedate>
     ///
     /// MagickGetReleaseDate() returns the ImageMagick release date.
     ///
-    pub fn get_release_date() -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string_no_free(MagickGetReleaseDate()) }
+    pub fn get_release_date() -> &'static CStr {
+        unsafe { CStr::from_ptr(MagickGetReleaseDate()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetresourcelimit>
@@ -1613,10 +1612,10 @@ impl<'a> MagickWand<'a> {
     ///
     /// (MagickLibVersion, MagickVersion)
     ///
-    pub fn get_version() -> (c_ulong, Result<String, FromUtf8Error>) {
+    pub fn get_version() -> (c_ulong, &'static CStr) {
         let mut version = 0;
         let c = unsafe { MagickGetVersion(&mut version) };
-        (version, unsafe { c_str_to_string_no_free(c) })
+        (version, unsafe { CStr::from_ptr(c) })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickhaldclutimage>
@@ -2328,11 +2327,13 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickQueryFonts() returns any font that match the specified pattern.
     ///
-    pub fn query_fonts(pattern: &str) -> Option<Vec<Result<String, FromUtf8Error>>> {
+    pub fn query_fonts(pattern: &str) -> Option<Vec<Option<MagickCString>>> {
         let pattern = str_to_c_string(pattern);
         let mut number_fonts = 0;
         let a = unsafe { MagickQueryFonts(pattern.as_ptr(), &mut number_fonts) };
-        c_arr_to_vec(a, number_fonts as usize, |s| unsafe { c_str_to_string(*s) })
+        c_arr_to_vec(a, number_fonts as usize, |s| unsafe {
+            MagickCString::new(*s)
+        })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickqueryformats>
@@ -2341,12 +2342,12 @@ impl<'a> MagickWand<'a> {
     ///
     /// pattern.
     ///
-    pub fn query_formats(pattern: &str) -> Option<Vec<Result<String, FromUtf8Error>>> {
+    pub fn query_formats(pattern: &str) -> Option<Vec<Option<MagickCString>>> {
         let pattern = str_to_c_string(pattern);
         let mut number_formats = 0;
         let a = unsafe { MagickQueryFormats(pattern.as_ptr(), &mut number_formats) };
         c_arr_to_vec(a, number_formats as usize, |s| unsafe {
-            c_str_to_string(*s)
+            MagickCString::new(*s)
         })
     }
 
@@ -2457,11 +2458,13 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickRemoveImageProfile() removes the named image profile and returns it.
     ///
-    pub fn remove_image_profile(&mut self, name: &str) -> Result<String, FromUtf8Error> {
+    pub fn remove_image_profile(&mut self, name: &str) -> Option<MagickCString> {
         let name = str_to_c_string(name);
         let mut length = 0;
         unsafe {
-            c_str_to_string(MagickRemoveImageProfile(self.wand, name.as_ptr(), &mut length).cast())
+            MagickCString::new(
+                MagickRemoveImageProfile(self.wand, name.as_ptr(), &mut length).cast(),
+            )
         }
     }
 

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -627,8 +627,7 @@ impl<'a> MagickWand<'a> {
     /// similar to the output of 'identify -verbose'.
     ///
     pub fn describe_image(&mut self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickDescribeImage(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickDescribeImage(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickdespeckleimage>
@@ -890,8 +889,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn get_configure_info(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let name = str_to_c_string(name);
-        let c = unsafe { MagickGetConfigureInfo(self.wand, name.as_ptr()) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickGetConfigureInfo(self.wand, name.as_ptr())) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetcopyright>
@@ -899,8 +897,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetCopyright() returns the ImageMagick API copyright as a string.
     ///
     pub fn get_copyright() -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetCopyright() };
-        c_str_to_string_no_free(c)
+        unsafe { c_str_to_string_no_free(MagickGetCopyright()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetfilename>
@@ -908,8 +905,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetFilename() returns the filename associated with an image sequence.
     ///
     pub fn get_filename(&self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetFilename(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickGetFilename(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgethomeurl>
@@ -917,8 +913,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetHomeURL() returns the ImageMagick home URL.
     ///
     pub fn get_home_url() -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetHomeURL() };
-        c_str_to_string_no_free(c)
+        unsafe { c_str_to_string_no_free(MagickGetHomeURL()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimage>
@@ -936,8 +931,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn get_image_attribute(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let name = str_to_c_string(name);
-        let c = unsafe { MagickGetImageAttribute(self.wand, name.as_ptr()) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickGetImageAttribute(self.wand, name.as_ptr())) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimagebackgroundcolor>
@@ -1165,8 +1159,7 @@ impl<'a> MagickWand<'a> {
     /// sequence.
     ///
     pub fn get_image_filename(&mut self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetImageFilename(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickGetImageFilename(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimageformat>
@@ -1176,8 +1169,7 @@ impl<'a> MagickWand<'a> {
     /// sequence.
     ///
     pub fn get_image_format(&mut self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetImageFormat(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickGetImageFormat(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimagefuzz>
@@ -1409,8 +1401,9 @@ impl<'a> MagickWand<'a> {
     pub fn get_image_profile(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let mut length = 0;
         let name = str_to_c_string(name);
-        let c = unsafe { MagickGetImageProfile(self.wand, name.as_ptr(), &mut length) };
-        c_str_to_string(c.cast())
+        unsafe {
+            c_str_to_string(MagickGetImageProfile(self.wand, name.as_ptr(), &mut length).cast())
+        }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimageredprimary>
@@ -1468,8 +1461,7 @@ impl<'a> MagickWand<'a> {
     /// pixel stream.
     ///
     pub fn get_image_signature(&mut self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetImageSignature(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(MagickGetImageSignature(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimagesize>
@@ -1557,8 +1549,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetPackageName() returns the ImageMagick package name.
     ///
     pub fn get_package_name() -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetPackageName() };
-        c_str_to_string_no_free(c)
+        unsafe { c_str_to_string_no_free(MagickGetPackageName()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetquantumdepth>
@@ -1568,7 +1559,7 @@ impl<'a> MagickWand<'a> {
     pub fn get_quantum_depth() -> (c_ulong, Result<String, FromUtf8Error>) {
         let mut depth = 0;
         let c = unsafe { MagickGetQuantumDepth(&mut depth) };
-        (depth, c_str_to_string_no_free(c))
+        (depth, unsafe { c_str_to_string_no_free(c) })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetreleasedate>
@@ -1576,8 +1567,7 @@ impl<'a> MagickWand<'a> {
     /// MagickGetReleaseDate() returns the ImageMagick release date.
     ///
     pub fn get_release_date() -> Result<String, FromUtf8Error> {
-        let c = unsafe { MagickGetReleaseDate() };
-        c_str_to_string_no_free(c)
+        unsafe { c_str_to_string_no_free(MagickGetReleaseDate()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetresourcelimit>
@@ -1626,7 +1616,7 @@ impl<'a> MagickWand<'a> {
     pub fn get_version() -> (c_ulong, Result<String, FromUtf8Error>) {
         let mut version = 0;
         let c = unsafe { MagickGetVersion(&mut version) };
-        (version, c_str_to_string_no_free(c))
+        (version, unsafe { c_str_to_string_no_free(c) })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickhaldclutimage>
@@ -2342,7 +2332,7 @@ impl<'a> MagickWand<'a> {
         let pattern = str_to_c_string(pattern);
         let mut number_fonts = 0;
         let a = unsafe { MagickQueryFonts(pattern.as_ptr(), &mut number_fonts) };
-        c_arr_to_vec(a, number_fonts as usize, |s| c_str_to_string(unsafe { *s }))
+        c_arr_to_vec(a, number_fonts as usize, |s| unsafe { c_str_to_string(*s) })
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickqueryformats>
@@ -2355,8 +2345,8 @@ impl<'a> MagickWand<'a> {
         let pattern = str_to_c_string(pattern);
         let mut number_formats = 0;
         let a = unsafe { MagickQueryFormats(pattern.as_ptr(), &mut number_formats) };
-        c_arr_to_vec(a, number_formats as usize, |s| {
-            c_str_to_string(unsafe { *s })
+        c_arr_to_vec(a, number_formats as usize, |s| unsafe {
+            c_str_to_string(*s)
         })
     }
 
@@ -2470,8 +2460,9 @@ impl<'a> MagickWand<'a> {
     pub fn remove_image_profile(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let name = str_to_c_string(name);
         let mut length = 0;
-        let c = unsafe { MagickRemoveImageProfile(self.wand, name.as_ptr(), &mut length) };
-        c_str_to_string(c.cast())
+        unsafe {
+            c_str_to_string(MagickRemoveImageProfile(self.wand, name.as_ptr(), &mut length).cast())
+        }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickresetiterator>

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -4112,7 +4112,7 @@ mod tests {
 
     #[test]
     fn test_magick_wand_get_copyright() {
-        MagickWand::get_copyright().unwrap();
+        MagickWand::get_copyright();
     }
 
     #[test]
@@ -4124,7 +4124,7 @@ mod tests {
     #[test]
     fn test_magick_wand_get_home_url() {
         let _mw = new_logo_magick_wand();
-        MagickWand::get_home_url().unwrap();
+        MagickWand::get_home_url();
     }
 
     #[test]
@@ -4436,17 +4436,17 @@ mod tests {
 
     #[test]
     fn test_magick_wand_get_package_name() {
-        MagickWand::get_package_name().unwrap();
+        MagickWand::get_package_name();
     }
 
     #[test]
     fn test_magick_wand_get_quantum_depth() {
-        MagickWand::get_quantum_depth().1.unwrap();
+        MagickWand::get_quantum_depth();
     }
 
     #[test]
     fn test_magick_wand_get_release_date() {
-        MagickWand::get_release_date().unwrap();
+        MagickWand::get_release_date();
     }
 
     #[test]
@@ -4468,7 +4468,7 @@ mod tests {
 
     #[test]
     fn test_magick_wand_get_version() {
-        MagickWand::get_version().1.unwrap();
+        MagickWand::get_version();
     }
 
     #[test]

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -20,7 +20,7 @@ use std::{
     os::raw::{c_double, c_float, c_long, c_uchar, c_uint, c_ulong, c_ushort, c_void},
     ptr::null_mut,
     slice,
-    str::Utf8Error,
+    string::FromUtf8Error,
 };
 
 #[cfg(feature = "v1_3_26")]
@@ -626,7 +626,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// similar to the output of 'identify -verbose'.
     ///
-    pub fn describe_image(&mut self) -> Result<String, Utf8Error> {
+    pub fn describe_image(&mut self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickDescribeImage(self.wand) };
         c_str_to_string(c)
     }
@@ -888,7 +888,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// NAME, VERSION, LIB_VERSION, COPYRIGHT, etc.
     ///
-    pub fn get_configure_info(&mut self, name: &str) -> Result<String, Utf8Error> {
+    pub fn get_configure_info(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let name = str_to_c_string(name);
         let c = unsafe { MagickGetConfigureInfo(self.wand, name.as_ptr()) };
         c_str_to_string(c)
@@ -898,7 +898,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetCopyright() returns the ImageMagick API copyright as a string.
     ///
-    pub fn get_copyright() -> Result<String, Utf8Error> {
+    pub fn get_copyright() -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetCopyright() };
         c_str_to_string_no_free(c)
     }
@@ -907,7 +907,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetFilename() returns the filename associated with an image sequence.
     ///
-    pub fn get_filename(&self) -> Result<String, Utf8Error> {
+    pub fn get_filename(&self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetFilename(self.wand) };
         c_str_to_string(c)
     }
@@ -916,7 +916,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetHomeURL() returns the ImageMagick home URL.
     ///
-    pub fn get_home_url() -> Result<String, Utf8Error> {
+    pub fn get_home_url() -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetHomeURL() };
         c_str_to_string_no_free(c)
     }
@@ -934,7 +934,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetImageAttribute returns an image attribute as a string
     ///
-    pub fn get_image_attribute(&mut self, name: &str) -> Result<String, Utf8Error> {
+    pub fn get_image_attribute(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let name = str_to_c_string(name);
         let c = unsafe { MagickGetImageAttribute(self.wand, name.as_ptr()) };
         c_str_to_string(c)
@@ -1164,7 +1164,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// sequence.
     ///
-    pub fn get_image_filename(&mut self) -> Result<String, Utf8Error> {
+    pub fn get_image_filename(&mut self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetImageFilename(self.wand) };
         c_str_to_string(c)
     }
@@ -1175,7 +1175,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// sequence.
     ///
-    pub fn get_image_format(&mut self) -> Result<String, Utf8Error> {
+    pub fn get_image_format(&mut self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetImageFormat(self.wand) };
         c_str_to_string(c)
     }
@@ -1406,7 +1406,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetImageProfile() returns the named image profile.
     ///
-    pub fn get_image_profile(&mut self, name: &str) -> Result<String, Utf8Error> {
+    pub fn get_image_profile(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let mut length = 0;
         let name = str_to_c_string(name);
         let c = unsafe { MagickGetImageProfile(self.wand, name.as_ptr(), &mut length) };
@@ -1467,7 +1467,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// pixel stream.
     ///
-    pub fn get_image_signature(&mut self) -> Result<String, Utf8Error> {
+    pub fn get_image_signature(&mut self) -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetImageSignature(self.wand) };
         c_str_to_string(c)
     }
@@ -1556,7 +1556,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetPackageName() returns the ImageMagick package name.
     ///
-    pub fn get_package_name() -> Result<String, Utf8Error> {
+    pub fn get_package_name() -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetPackageName() };
         c_str_to_string_no_free(c)
     }
@@ -1565,7 +1565,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetQuantumDepth() returns the ImageMagick quantum depth.
     ///
-    pub fn get_quantum_depth() -> (c_ulong, Result<String, Utf8Error>) {
+    pub fn get_quantum_depth() -> (c_ulong, Result<String, FromUtf8Error>) {
         let mut depth = 0;
         let c = unsafe { MagickGetQuantumDepth(&mut depth) };
         (depth, c_str_to_string_no_free(c))
@@ -1575,7 +1575,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetReleaseDate() returns the ImageMagick release date.
     ///
-    pub fn get_release_date() -> Result<String, Utf8Error> {
+    pub fn get_release_date() -> Result<String, FromUtf8Error> {
         let c = unsafe { MagickGetReleaseDate() };
         c_str_to_string_no_free(c)
     }
@@ -1623,7 +1623,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// (MagickLibVersion, MagickVersion)
     ///
-    pub fn get_version() -> (c_ulong, Result<String, Utf8Error>) {
+    pub fn get_version() -> (c_ulong, Result<String, FromUtf8Error>) {
         let mut version = 0;
         let c = unsafe { MagickGetVersion(&mut version) };
         (version, c_str_to_string_no_free(c))
@@ -2338,7 +2338,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickQueryFonts() returns any font that match the specified pattern.
     ///
-    pub fn query_fonts(pattern: &str) -> Option<Vec<Result<String, Utf8Error>>> {
+    pub fn query_fonts(pattern: &str) -> Option<Vec<Result<String, FromUtf8Error>>> {
         let pattern = str_to_c_string(pattern);
         let mut number_fonts = 0;
         let a = unsafe { MagickQueryFonts(pattern.as_ptr(), &mut number_fonts) };
@@ -2351,7 +2351,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// pattern.
     ///
-    pub fn query_formats(pattern: &str) -> Option<Vec<Result<String, Utf8Error>>> {
+    pub fn query_formats(pattern: &str) -> Option<Vec<Result<String, FromUtf8Error>>> {
         let pattern = str_to_c_string(pattern);
         let mut number_formats = 0;
         let a = unsafe { MagickQueryFormats(pattern.as_ptr(), &mut number_formats) };
@@ -2467,7 +2467,7 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickRemoveImageProfile() removes the named image profile and returns it.
     ///
-    pub fn remove_image_profile(&mut self, name: &str) -> Result<String, Utf8Error> {
+    pub fn remove_image_profile(&mut self, name: &str) -> Result<String, FromUtf8Error> {
         let name = str_to_c_string(name);
         let mut length = 0;
         let c = unsafe { MagickRemoveImageProfile(self.wand, name.as_ptr(), &mut length) };

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -114,8 +114,7 @@ impl PixelWand {
     /// PixelGetColorAsString() gets the color of the pixel wand.
     ///
     pub fn get_color_as_string(&mut self) -> Result<String, FromUtf8Error> {
-        let c = unsafe { PixelGetColorAsString(self.wand) };
-        c_str_to_string(c)
+        unsafe { c_str_to_string(PixelGetColorAsString(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetcolorcount>

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -2,12 +2,11 @@
 //!
 //! <http://www.graphicsmagick.org/wand/pixel_wand.html>
 
-use crate::utils::{assert_initialized, c_str_to_string, str_to_c_string};
+use crate::utils::{assert_initialized, str_to_c_string, MagickCString};
 use graphicsmagick_sys::*;
 use std::{
     os::raw::{c_double, c_ulong},
     ptr::null_mut,
-    string::FromUtf8Error,
 };
 
 /// Wrapper of `graphicsmagick_sys::PixelWand`.
@@ -113,8 +112,8 @@ impl PixelWand {
     ///
     /// PixelGetColorAsString() gets the color of the pixel wand.
     ///
-    pub fn get_color_as_string(&mut self) -> Result<String, FromUtf8Error> {
-        unsafe { c_str_to_string(PixelGetColorAsString(self.wand)) }
+    pub fn get_color_as_string(&mut self) -> Option<MagickCString> {
+        unsafe { MagickCString::new(PixelGetColorAsString(self.wand)) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetcolorcount>

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -112,7 +112,7 @@ impl PixelWand {
     ///
     /// PixelGetColorAsString() gets the color of the pixel wand.
     ///
-    pub fn get_color_as_string(&mut self) -> Option<MagickCString> {
+    pub fn get_color_as_string(&mut self) -> MagickCString {
         unsafe { MagickCString::new(PixelGetColorAsString(self.wand)) }
     }
 
@@ -462,7 +462,7 @@ mod tests {
     #[test]
     fn test_pixel_wand_get_color_as_string() {
         let mut pw = new_pixel_wand();
-        pw.get_color_as_string().unwrap();
+        pw.get_color_as_string().to_str().unwrap();
     }
 
     #[test]

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -7,7 +7,7 @@ use graphicsmagick_sys::*;
 use std::{
     os::raw::{c_double, c_ulong},
     ptr::null_mut,
-    str::Utf8Error,
+    string::FromUtf8Error,
 };
 
 /// Wrapper of `graphicsmagick_sys::PixelWand`.
@@ -113,7 +113,7 @@ impl PixelWand {
     ///
     /// PixelGetColorAsString() gets the color of the pixel wand.
     ///
-    pub fn get_color_as_string(&mut self) -> Result<String, Utf8Error> {
+    pub fn get_color_as_string(&mut self) -> Result<String, FromUtf8Error> {
         let c = unsafe { PixelGetColorAsString(self.wand) };
         c_str_to_string(c)
     }


### PR DESCRIPTION
Plus:
 - [Improve doc for initialize](https://github.com/jmjoy/graphicsmagick-rs/commit/aeb9ba5c59cd07d98e5fd81f4cdb98aec7708020)
 - [Optimize str_to_c_string: from_vec_unchecked appends \0](https://github.com/jmjoy/graphicsmagick-rs/commit/cf79d22c9c80c2449c816db21cead68a98b29918)
 - [FIx: Call MagickFree on unwinding & refactor c_str_to_string](https://github.com/jmjoy/graphicsmagick-rs/commit/6e5ec82f027f47aebc207b78ca86d5350ff86d2b)
 - [FIx: Call MagickFree in c_arr_to_vec on unwinding](https://github.com/jmjoy/graphicsmagick-rs/commit/0022f234b6d83909d1bbbba5b69080f455265d27)
 - [Mark c_str_to_string* as unsafe](https://github.com/jmjoy/graphicsmagick-rs/commit/62fa57c305bb69b1fc9e9475e7085fa5d93e0be6)

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>