### PR TITLE
Optimize: Return `MagickBoxSlice` in place of `Vec` to archive zero-cost

### DIFF
--- a/graphicsmagick/src/lib.rs
+++ b/graphicsmagick/src/lib.rs
@@ -15,5 +15,5 @@ pub mod wand;
 
 pub use crate::{
     error::{Error, Result},
-    utils::{has_initialized, initialize, max_rgb, MagickCString, MaxRGB},
+    utils::{has_initialized, initialize, max_rgb, MagickCString, MagickIter, MaxRGB},
 };

--- a/graphicsmagick/src/lib.rs
+++ b/graphicsmagick/src/lib.rs
@@ -15,5 +15,7 @@ pub mod wand;
 
 pub use crate::{
     error::{Error, Result},
-    utils::{has_initialized, initialize, max_rgb, MagickCString, MagickIter, MaxRGB},
+    utils::{
+        has_initialized, initialize, max_rgb, MagickBoxSlice, MagickCString, MagickIter, MaxRGB,
+    },
 };

--- a/graphicsmagick/src/lib.rs
+++ b/graphicsmagick/src/lib.rs
@@ -15,7 +15,5 @@ pub mod wand;
 
 pub use crate::{
     error::{Error, Result},
-    utils::{
-        has_initialized, initialize, max_rgb, MagickBoxSlice, MagickCString, MagickIter, MaxRGB,
-    },
+    utils::{has_initialized, initialize, max_rgb, MagickBoxSlice, MagickCString, MaxRGB},
 };

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -114,6 +114,7 @@ where
 }
 
 #[derive(Debug)]
+#[repr(transparent)]
 pub struct MagickCString(*const c_char);
 
 impl MagickCString {

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -164,63 +164,6 @@ pub(crate) trait CStrExt {
 impl CStrExt for CStr {}
 
 #[derive(Debug)]
-pub struct MagickIter<U> {
-    alloc: MagickAlloc,
-
-    index: usize,
-    /// len of the array
-    len: usize,
-
-    /// mem::size_of::<T>
-    size: usize,
-
-    /// The transformer
-    f: fn(*mut ()) -> U,
-}
-
-impl<U> MagickIter<U> {
-    /// Return `None` if `a.is_null()`.
-    ///
-    ///  * `f` - takes in `*mut T` (takes ownership) and produces `U`.
-    pub(crate) unsafe fn new<T>(a: *const T, len: usize, f: fn(*mut T) -> U) -> Option<Self> {
-        if a.is_null() {
-            None
-        } else {
-            Some(Self {
-                alloc: MagickAlloc::new(a as *mut c_void),
-                index: 0,
-                len,
-                size: mem::size_of::<T>(),
-                f: mem::transmute(f),
-            })
-        }
-    }
-}
-
-impl<U> Iterator for MagickIter<U> {
-    type Item = U;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index == self.len {
-            return None;
-        }
-
-        // Use *mut u8 pointer since its size is 1.
-        let base_ptr = self.alloc.0 as *mut u8;
-
-        // Calculate the pointer
-        let p = unsafe { base_ptr.add(self.index * self.size) };
-
-        // Incr the index
-        self.index += 1;
-
-        Some((self.f)(p as *mut ()))
-    }
-}
-
-impl<U> ExactSizeIterator for MagickIter<U> {}
-
-#[derive(Debug)]
 pub struct MagickBoxSlice<T> {
     alloc: MagickAlloc,
     len: usize,

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -168,18 +168,28 @@ impl<T> MagickBoxSlice<T> {
             phantom: PhantomData,
         })
     }
+
+    /// Return pointer to the underlying data
+    pub fn as_ptr(&self) -> *const T {
+        self.alloc.0 as *const T
+    }
+
+    /// Return pointer to the underlying data
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.alloc.0 as *mut T
+    }
 }
 
 impl<T> Deref for MagickBoxSlice<T> {
     type Target = [T];
 
     fn deref(&self) -> &Self::Target {
-        unsafe { from_raw_parts(self.alloc.0 as *const T, self.len) }
+        unsafe { from_raw_parts(self.as_ptr(), self.len) }
     }
 }
 
 impl<T> DerefMut for MagickBoxSlice<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { from_raw_parts_mut(self.alloc.0 as *mut T, self.len) }
+        unsafe { from_raw_parts_mut(self.as_mut_ptr(), self.len) }
     }
 }

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -95,26 +95,6 @@ impl Drop for MagickAlloc {
     }
 }
 
-pub(crate) fn c_arr_to_vec<T, U, F>(a: *const T, len: usize, f: F) -> Option<Vec<U>>
-where
-    F: Fn(*const T) -> U,
-{
-    if a.is_null() {
-        return None;
-    }
-
-    // Use MagickAlloc to ensure a is free on unwinding.
-    let _magick_vec = unsafe { MagickAlloc::new(a as *mut c_void) };
-
-    let mut v = Vec::with_capacity(len);
-    for i in 0..len {
-        let p = unsafe { a.add(i) };
-        v.push(f(p));
-    }
-
-    Some(v)
-}
-
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct MagickCString(MagickAlloc);

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -104,13 +104,18 @@ impl MagickCString {
         Self(MagickAlloc(c as *mut c_void))
     }
 
+    /// Return pointer to the underlying data.
+    pub fn as_ptr(&self) -> *const c_char {
+        self.0 .0 as *const c_char
+    }
+
     /// Convert [`MagickCString`] to [`CStr`].
     pub fn as_c_str(&self) -> &CStr {
-        let ptr = self.0 .0;
+        let ptr = self.as_ptr();
         if ptr.is_null() {
             unsafe { CStr::from_bytes_with_nul_unchecked(b"\0") }
         } else {
-            unsafe { CStr::from_ptr(ptr as *mut c_char) }
+            unsafe { CStr::from_ptr(ptr) }
         }
     }
 

--- a/graphicsmagick/src/utils.rs
+++ b/graphicsmagick/src/utils.rs
@@ -150,6 +150,16 @@ impl MagickCString {
     }
 }
 
+impl Drop for MagickCString {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                graphicsmagick_sys::MagickFree(self.0 as *mut c_void);
+            }
+        }
+    }
+}
+
 pub(crate) trait CStrExt {
     unsafe fn from_ptr_checked_on_debug<'a>(ptr: *const c_char) -> &'a CStr {
         debug_assert!(!ptr.is_null());

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -7,9 +7,9 @@ use crate::{
         ClipPathUnits, DecorationType, FillRule, GravityType, LineCap, LineJoin, PaintMethod,
         StretchType, StyleType,
     },
-    utils::{assert_initialized, c_arr_to_vec, str_to_c_string},
+    utils::{assert_initialized, str_to_c_string},
     wand::pixel::PixelWand,
-    MagickCString,
+    MagickBoxSlice, MagickCString,
 };
 use graphicsmagick_sys::*;
 use std::{
@@ -1308,10 +1308,10 @@ impl DrawingWand {
     ///
     /// array must be freed once it is no longer required by the user.
     ///
-    pub fn get_stroke_dash_array(&self) -> Option<Vec<c_double>> {
+    pub fn get_stroke_dash_array(&self) -> Option<MagickBoxSlice<c_double>> {
         let mut number_elements = 0;
         let a = unsafe { MagickDrawGetStrokeDashArray(self.wand, &mut number_elements) };
-        c_arr_to_vec(a, number_elements as usize, |e| unsafe { *e })
+        unsafe { MagickBoxSlice::new(a, number_elements.try_into().unwrap()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/drawing_wand.html#drawsetstrokedasharray>

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -9,7 +9,7 @@ use crate::{
         ImageType, InterlaceType, MetricType, MontageMode, NoiseType, PreviewType, RenderingIntent,
         ResolutionType, ResourceType, VirtualPixelMethod,
     },
-    utils::{assert_initialized, c_arr_to_vec, str_to_c_string, CStrExt},
+    utils::{assert_initialized, str_to_c_string, CStrExt},
     wand::{DrawingWand, PixelWand},
     MagickBoxSlice, MagickCString,
 };

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     utils::{assert_initialized, c_arr_to_vec, str_to_c_string, CStrExt},
     wand::{DrawingWand, PixelWand},
-    MagickCString,
+    MagickBoxSlice, MagickCString,
 };
 use graphicsmagick_sys::*;
 use std::{
@@ -1240,12 +1240,10 @@ impl<'a> MagickWand<'a> {
     ///
     /// PixelWand wands.
     ///
-    pub fn get_image_histogram(&mut self) -> Option<Vec<PixelWand>> {
+    pub fn get_image_histogram(&mut self) -> Option<MagickBoxSlice<PixelWand>> {
         let mut number_colors = 0;
         let wands = unsafe { MagickGetImageHistogram(self.wand, &mut number_colors) };
-        c_arr_to_vec(wands, number_colors as usize, |wand| {
-            PixelWand::from_wand_expect(unsafe { *wand })
-        })
+        unsafe { MagickBoxSlice::new(wands, number_colors.try_into().unwrap()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimageindex>
@@ -1588,10 +1586,10 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickGetSamplingFactors() gets the horizontal and vertical sampling factor.
     ///
-    pub fn get_sampling_factors(&mut self) -> Option<Vec<c_double>> {
+    pub fn get_sampling_factors(&mut self) -> Option<MagickBoxSlice<c_double>> {
         let mut number_factors = 0;
         let a = unsafe { MagickGetSamplingFactors(self.wand, &mut number_factors) };
-        c_arr_to_vec(a, number_factors as usize, |p| unsafe { *p })
+        unsafe { MagickBoxSlice::new(a, number_factors.try_into().unwrap()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetsize>
@@ -2334,13 +2332,11 @@ impl<'a> MagickWand<'a> {
     ///
     /// MagickQueryFonts() returns any font that match the specified pattern.
     ///
-    pub fn query_fonts(pattern: &str) -> Option<Vec<MagickCString>> {
+    pub fn query_fonts(pattern: &str) -> Option<MagickBoxSlice<MagickCString>> {
         let pattern = str_to_c_string(pattern);
         let mut number_fonts = 0;
         let a = unsafe { MagickQueryFonts(pattern.as_ptr(), &mut number_fonts) };
-        c_arr_to_vec(a, number_fonts as usize, |s| unsafe {
-            MagickCString::new(*s)
-        })
+        unsafe { MagickBoxSlice::new(a, number_fonts.try_into().unwrap()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickqueryformats>
@@ -2349,13 +2345,11 @@ impl<'a> MagickWand<'a> {
     ///
     /// pattern.
     ///
-    pub fn query_formats(pattern: &str) -> Option<Vec<MagickCString>> {
+    pub fn query_formats(pattern: &str) -> Option<MagickBoxSlice<MagickCString>> {
         let pattern = str_to_c_string(pattern);
         let mut number_formats = 0;
         let a = unsafe { MagickQueryFormats(pattern.as_ptr(), &mut number_formats) };
-        c_arr_to_vec(a, number_formats as usize, |s| unsafe {
-            MagickCString::new(*s)
-        })
+        unsafe { MagickBoxSlice::new(a, number_formats.try_into().unwrap()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickradialblurimage>
@@ -3697,13 +3691,10 @@ impl<'a> MagickWand<'a> {
     ///
     /// at the beginning.
     ///
-    pub fn write_image_blob(&mut self) -> Option<Vec<u8>> {
+    pub fn write_image_blob(&mut self) -> Option<MagickBoxSlice<u8>> {
         let mut length = 0;
         let ptr = unsafe { MagickWriteImageBlob(self.wand, &mut length) };
-        if ptr.is_null() {
-            return None;
-        }
-        Some(unsafe { Vec::from_raw_parts(ptr, length as usize, length as usize) })
+        unsafe { MagickBoxSlice::new(ptr, length.try_into().unwrap()) }
     }
 
     // Not need

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -35,11 +35,6 @@ impl PixelWand {
     }
 
     #[inline]
-    pub(crate) fn from_wand_expect(wand: *mut graphicsmagick_sys::PixelWand) -> PixelWand {
-        Self::from_wand(wand).expect("wand cant't be null")
-    }
-
-    #[inline]
     pub fn wand(&self) -> *const graphicsmagick_sys::PixelWand {
         self.wand
     }

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 /// Wrapper of `graphicsmagick_sys::PixelWand`.
+#[repr(transparent)]
 pub struct PixelWand {
     wand: *mut graphicsmagick_sys::PixelWand,
 }


### PR DESCRIPTION
Also fix incorrect use of `Vec::from_raw_parts` on allocation made by graphicsmagick.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>