### PR TITLE
Impl `MagickWandExportType` directly on `c_unchar` ... & impl new fn `MagickWand::write_image_pixels_to`

### DIFF
--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -1340,14 +1340,14 @@ impl<'a> MagickWand<'a> {
     ///
     /// ```
     /// use graphicsmagick::{
-    ///     wand::{MagickWand, MagickWandExportCharPixel},
+    ///     wand::{MagickWand},
     ///     initialize,
     /// };
     ///
     /// initialize();
     ///
     /// MagickWand::new()
-    ///     .get_image_pixels::<MagickWandExportCharPixel>(0, 0, 640, 1, "RGB");
+    ///     .get_image_pixels::<u8>(0, 0, 640, 1, "RGB");
     /// ```
     ///
     pub fn get_image_pixels<ExportType: MagickWandExportType>(

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -16,7 +16,6 @@ use crate::{
 use graphicsmagick_sys::*;
 use std::{
     ffi::CStr,
-    fmt,
     marker::PhantomData,
     os::raw::{c_double, c_float, c_long, c_uchar, c_uint, c_ulong, c_ushort, c_void},
     ptr::null_mut,
@@ -31,41 +30,28 @@ use crate::types::GravityType;
 
 /// # Safety
 ///
-/// `STORAGE_TYPE` must match `TARGET`.
+/// `STORAGE_TYPE` must match the type being implemented.
 pub unsafe trait MagickWandExportTypeSealed {
     const STORAGE_TYPE: StorageType;
-
-    /// Make using it in generic code easier.
-    type Target: fmt::Debug + fmt::Display + Copy + Clone;
 }
 
 pub trait MagickWandExportType: MagickWandExportTypeSealed {}
 
 macro_rules! def_magickwand_export_type {
-    ($name:ident, $STORAGE_TYPE:expr, $Target:ty) => {
-        pub struct $name;
-        unsafe impl MagickWandExportTypeSealed for $name {
+    ($STORAGE_TYPE:expr, $type:ty) => {
+        unsafe impl MagickWandExportTypeSealed for $type {
             const STORAGE_TYPE: StorageType = $STORAGE_TYPE;
-            type Target = $Target;
         }
-        impl MagickWandExportType for $name {}
+        impl MagickWandExportType for $type {}
     };
 }
 
-def_magickwand_export_type!(MagickWandExportCharPixel, StorageType_CharPixel, c_uchar);
-def_magickwand_export_type!(MagickWandExportShortPixel, StorageType_ShortPixel, c_ushort);
-def_magickwand_export_type!(
-    MagickWandExportIntegerPixel,
-    StorageType_IntegerPixel,
-    c_uint
-);
-def_magickwand_export_type!(MagickWandExportLongPixel, StorageType_LongPixel, c_ulong);
-def_magickwand_export_type!(MagickWandExportFloatPixel, StorageType_FloatPixel, c_float);
-def_magickwand_export_type!(
-    MagickWandExportDoublePixel,
-    StorageType_DoublePixel,
-    c_double
-);
+def_magickwand_export_type!(StorageType_CharPixel, c_uchar);
+def_magickwand_export_type!(StorageType_ShortPixel, c_ushort);
+def_magickwand_export_type!(StorageType_IntegerPixel, c_uint);
+def_magickwand_export_type!(StorageType_LongPixel, c_ulong);
+def_magickwand_export_type!(StorageType_FloatPixel, c_float);
+def_magickwand_export_type!(StorageType_DoublePixel, c_double);
 
 /// Wrapper of `graphicsmagick_sys::MagickWand`.
 pub struct MagickWand<'a> {
@@ -1367,7 +1353,7 @@ impl<'a> MagickWand<'a> {
         columns: c_ulong,
         rows: c_ulong,
         map: &str,
-    ) -> crate::Result<Vec<ExportType::Target>> {
+    ) -> crate::Result<Vec<ExportType>> {
         let size: usize = (columns * rows).try_into().unwrap();
         let len = size * map.len();
 
@@ -4347,12 +4333,12 @@ mod tests {
 
     #[test]
     fn test_magick_wand_get_image_pixels() {
-        test_magick_wand_get_image_pixels_inner::<MagickWandExportCharPixel>();
-        test_magick_wand_get_image_pixels_inner::<MagickWandExportShortPixel>();
-        test_magick_wand_get_image_pixels_inner::<MagickWandExportIntegerPixel>();
-        test_magick_wand_get_image_pixels_inner::<MagickWandExportLongPixel>();
-        test_magick_wand_get_image_pixels_inner::<MagickWandExportFloatPixel>();
-        test_magick_wand_get_image_pixels_inner::<MagickWandExportDoublePixel>();
+        test_magick_wand_get_image_pixels_inner::<c_uchar>();
+        test_magick_wand_get_image_pixels_inner::<c_ushort>();
+        test_magick_wand_get_image_pixels_inner::<c_uint>();
+        test_magick_wand_get_image_pixels_inner::<c_ulong>();
+        test_magick_wand_get_image_pixels_inner::<c_float>();
+        test_magick_wand_get_image_pixels_inner::<c_double>();
     }
 
     #[test]

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -28,18 +28,22 @@ use crate::types::OrientationType;
 #[cfg(feature = "v1_3_22")]
 use crate::types::GravityType;
 
-/// # Safety
-///
-/// `STORAGE_TYPE` must match the type being implemented.
-pub unsafe trait MagickWandExportTypeSealed {
-    const STORAGE_TYPE: StorageType;
+mod sealed {
+    use super::StorageType;
+
+    /// # Safety
+    ///
+    /// `STORAGE_TYPE` must match the type being implemented.
+    pub unsafe trait MagickWandExportTypeSealed {
+        const STORAGE_TYPE: StorageType;
+    }
 }
 
-pub trait MagickWandExportType: MagickWandExportTypeSealed {}
+pub trait MagickWandExportType: sealed::MagickWandExportTypeSealed {}
 
 macro_rules! def_magickwand_export_type {
     ($STORAGE_TYPE:expr, $type:ty) => {
-        unsafe impl MagickWandExportTypeSealed for $type {
+        unsafe impl sealed::MagickWandExportTypeSealed for $type {
             const STORAGE_TYPE: StorageType = $STORAGE_TYPE;
         }
         impl MagickWandExportType for $type {}

--- a/graphicsmagick/src/wand/mod.rs
+++ b/graphicsmagick/src/wand/mod.rs
@@ -6,12 +6,4 @@ pub mod drawing;
 pub mod magick;
 pub mod pixel;
 
-pub use self::{
-    drawing::DrawingWand,
-    magick::{
-        MagickWand, MagickWandExportCharPixel, MagickWandExportDoublePixel,
-        MagickWandExportFloatPixel, MagickWandExportIntegerPixel, MagickWandExportLongPixel,
-        MagickWandExportShortPixel,
-    },
-    pixel::PixelWand,
-};
+pub use self::{drawing::DrawingWand, magick::MagickWand, pixel::PixelWand};


### PR DESCRIPTION
Also [FIx MagickWandExportTypeSealed: Properly seal that trait](https://github.com/jmjoy/graphicsmagick-rs/commit/3e00734aeae3d13a4032b9c619469c0da0397ad9).

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>