### PR TITLE
Use `NonNull`, mark `from_wand` as `unsafe`, re-export types used in mod `wand`, etc

### DIFF
--- a/graphicsmagick/Cargo.toml
+++ b/graphicsmagick/Cargo.toml
@@ -44,6 +44,7 @@ thiserror = "1.0.30"
 [dev-dependencies]
 anyhow = "1.0.53"
 env_logger = "0.9.0"
+once_cell = "1.13.1"
 
 [build-dependencies]
 anyhow = "1.0.53"

--- a/graphicsmagick/Cargo.toml
+++ b/graphicsmagick/Cargo.toml
@@ -38,7 +38,6 @@ v1_3_38 = ["v1_3_37"]
 
 [dependencies]
 graphicsmagick-sys = { version = "0.1.2", path = "../graphicsmagick-sys" }
-libc = "0.2.117"
 thiserror = "1.0.30"
 
 [dev-dependencies]

--- a/graphicsmagick/Cargo.toml
+++ b/graphicsmagick/Cargo.toml
@@ -43,7 +43,6 @@ thiserror = "1.0.30"
 [dev-dependencies]
 anyhow = "1.0.53"
 env_logger = "0.9.0"
-once_cell = "1.13.1"
 
 [build-dependencies]
 anyhow = "1.0.53"

--- a/graphicsmagick/src/error.rs
+++ b/graphicsmagick/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error as ThisError;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Crate error.
+#[non_exhaustive]
 #[derive(ThisError, Debug)]
 pub enum Error {
     /// GraphicsMagick Exception.

--- a/graphicsmagick/src/error.rs
+++ b/graphicsmagick/src/error.rs
@@ -1,6 +1,5 @@
 //! Crate level errors.
 
-use std::str::Utf8Error;
 use thiserror::Error as ThisError;
 
 /// Crate result.
@@ -9,10 +8,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Crate error.
 #[derive(ThisError, Debug)]
 pub enum Error {
-    /// Utf8 Error.
-    #[error(transparent)]
-    Utf8(#[from] Utf8Error),
-
     /// GraphicsMagick Exception.
     #[error(transparent)]
     Exception(#[from] Exception),

--- a/graphicsmagick/src/tests.rs
+++ b/graphicsmagick/src/tests.rs
@@ -1,11 +1,11 @@
 pub(crate) fn logo_path() -> String {
     let mut path = std::env::var("PWD").unwrap();
-    path.extend("/meta/GraphicsMagick-Logo.webp".chars());
+    path.push_str("/meta/GraphicsMagick-Logo.webp");
     path
 }
 
 pub(crate) fn logo_unicode_path() -> String {
     let mut path = std::env::var("PWD").unwrap();
-    path.extend("/meta/GraphicsMagick-图标.webp".chars());
+    path.push_str("/meta/GraphicsMagick-图标.webp");
     path
 }

--- a/graphicsmagick/src/types.rs
+++ b/graphicsmagick/src/types.rs
@@ -2,7 +2,7 @@
 //!
 //! <http://www.graphicsmagick.org/api/types.html>
 
-pub use graphicsmagick_sys::{AffineMatrix, PixelPacket, PointInfo};
+pub use graphicsmagick_sys::{AffineMatrix, PixelPacket, PointInfo, Quantum};
 
 types_enum_block! {
     /// <http://www.graphicsmagick.org/api/types.html#channeltype>

--- a/graphicsmagick/src/types.rs
+++ b/graphicsmagick/src/types.rs
@@ -2,6 +2,8 @@
 //!
 //! <http://www.graphicsmagick.org/api/types.html>
 
+pub use graphicsmagick_sys::{AffineMatrix, PointInfo};
+
 types_enum_block! {
     /// <http://www.graphicsmagick.org/api/types.html#channeltype>
     ChannelType;

--- a/graphicsmagick/src/types.rs
+++ b/graphicsmagick/src/types.rs
@@ -2,7 +2,7 @@
 //!
 //! <http://www.graphicsmagick.org/api/types.html>
 
-pub use graphicsmagick_sys::{AffineMatrix, PointInfo};
+pub use graphicsmagick_sys::{AffineMatrix, PixelPacket, PointInfo};
 
 types_enum_block! {
     /// <http://www.graphicsmagick.org/api/types.html#channeltype>

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 /// Wrapper of `graphicsmagick_sys::DrawingWand`.
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct DrawingWand {
     wand: NonNull<graphicsmagick_sys::DrawingWand>,

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 /// Wrapper of `graphicsmagick_sys::DrawingWand`.
+#[repr(transparent)]
 pub struct DrawingWand {
     wand: NonNull<graphicsmagick_sys::DrawingWand>,
 }

--- a/graphicsmagick/src/wand/drawing.rs
+++ b/graphicsmagick/src/wand/drawing.rs
@@ -4,8 +4,8 @@
 
 use crate::{
     types::{
-        ClipPathUnits, DecorationType, FillRule, GravityType, LineCap, LineJoin, PaintMethod,
-        StretchType, StyleType,
+        AffineMatrix, ClipPathUnits, DecorationType, FillRule, GravityType, LineCap, LineJoin,
+        PaintMethod, StretchType, StyleType,
     },
     utils::{assert_initialized, str_to_c_string},
     wand::pixel::PixelWand,
@@ -1618,8 +1618,14 @@ impl DrawingWand {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::initialize;
+    use crate::{
+        initialize,
+        types::{
+            AffineMatrix, ClipPathUnits, DecorationType, FillRule, GravityType, LineCap, LineJoin,
+            PaintMethod, PointInfo, StretchType, StyleType,
+        },
+        wand::{DrawingWand, PixelWand},
+    };
 
     fn new_logo_drawing_wand() -> DrawingWand {
         initialize();

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -104,10 +104,8 @@ impl MagickWand<'_> {
         }
         let description =
             slice::from_raw_parts(description_ptr as *const u8, libc::strlen(description_ptr));
-        let description = match std::str::from_utf8(description) {
-            Ok(description) => description.to_string(),
-            Err(e) => return e.into(),
-        };
+
+        let description = String::from_utf8_lossy(description).into_owned();
         MagickRelinquishMemory(description_ptr as *mut c_void);
         Exception::new(severity.into(), description).into()
     }

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -3902,21 +3902,26 @@ impl<'a> MagickWand<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{
         initialize,
         tests::{logo_path, logo_unicode_path},
+        types::*,
+        wand::{magick::MagickWandExportType, DrawingWand, MagickWand, PixelWand},
     };
-    use std::{fs::File, io::Read};
+    use std::{
+        fs::File,
+        io::Read,
+        os::raw::{c_double, c_float, c_uchar, c_uint, c_ulong, c_ushort},
+    };
 
-    fn new_magick_wand<'a>() -> MagickWand<'a> {
+    fn new_magick_wand() -> MagickWand<'static> {
         initialize();
         MagickWand::new()
     }
 
-    fn new_logo_magick_wand<'a>() -> MagickWand<'a> {
+    fn new_logo_magick_wand() -> MagickWand<'static> {
         let mut mw = new_magick_wand();
-        mw.read_image(&logo_unicode_path()).unwrap();
+        mw.read_image(logo_unicode_path().leak()).unwrap();
         mw
     }
 

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -6,8 +6,8 @@ use crate::{
     error::Exception,
     types::{
         ChannelType, ColorspaceType, CompositeOperator, CompressionType, DisposeType, FilterTypes,
-        ImageType, InterlaceType, MetricType, MontageMode, NoiseType, PreviewType, RenderingIntent,
-        ResolutionType, ResourceType, VirtualPixelMethod,
+        ImageType, InterlaceType, MetricType, MontageMode, NoiseType, PreviewType, Quantum,
+        RenderingIntent, ResolutionType, ResourceType, VirtualPixelMethod,
     },
     utils::{assert_initialized, str_to_c_string, CStrExt},
     wand::{DrawingWand, PixelWand},

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -3921,7 +3921,7 @@ mod tests {
 
     fn new_logo_magick_wand() -> MagickWand<'static> {
         let mut mw = new_magick_wand();
-        mw.read_image(logo_unicode_path().leak()).unwrap();
+        mw.read_image(&logo_unicode_path()).unwrap();
         mw
     }
 

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -100,7 +100,7 @@ impl MagickWand<'_> {
             MagickGetException(self.wand.as_ptr(), &mut severity as *mut ExceptionType);
 
         if description_ptr.is_null() {
-            return Exception::new(0.into(), "Unknown exception".to_string()).into();
+            return Exception::new(severity.into(), "Unknown exception".to_string()).into();
         }
         let description =
             slice::from_raw_parts(description_ptr as *const u8, libc::strlen(description_ptr));

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -59,6 +59,7 @@ def_magickwand_export_type!(StorageType_FloatPixel, c_float);
 def_magickwand_export_type!(StorageType_DoublePixel, c_double);
 
 /// Wrapper of `graphicsmagick_sys::MagickWand`.
+#[repr(transparent)]
 pub struct MagickWand<'a> {
     wand: NonNull<graphicsmagick_sys::MagickWand>,
     phantom: PhantomData<&'a [u8]>,

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -59,6 +59,7 @@ def_magickwand_export_type!(StorageType_FloatPixel, c_float);
 def_magickwand_export_type!(StorageType_DoublePixel, c_double);
 
 /// Wrapper of `graphicsmagick_sys::MagickWand`.
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct MagickWand<'a> {
     wand: NonNull<graphicsmagick_sys::MagickWand>,

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -112,8 +112,11 @@ impl MagickWand<'_> {
         Exception::new(severity.into(), description).into()
     }
 
+    /// # Safety
+    ///
+    ///  * `wand` - must points to either NULL, or a valid allocation.
     #[inline]
-    pub fn from_wand(wand: *mut graphicsmagick_sys::MagickWand) -> Option<Self> {
+    pub unsafe fn from_wand(wand: *mut graphicsmagick_sys::MagickWand) -> Option<Self> {
         NonNull::new(wand).map(|wand| MagickWand {
             wand,
             phantom: PhantomData,
@@ -257,7 +260,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn append_images(&mut self, stack: c_uint) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickAppendImages(self.wand.as_ptr(), stack) };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickautoorientimage>
@@ -283,7 +286,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn average_images(&mut self) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickAverageImages(self.wand.as_ptr()) };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickblackthresholdimage>
@@ -449,7 +452,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn coalesce_images(&mut self) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickCoalesceImages(self.wand.as_ptr()) };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickcolorfloodfillimage>
@@ -529,7 +532,7 @@ impl<'a> MagickWand<'a> {
                 distortion,
             )
         };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickcompareimages>
@@ -552,7 +555,7 @@ impl<'a> MagickWand<'a> {
                 distortion,
             )
         };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickcompositeimage>
@@ -642,7 +645,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn deconstruct_images(&mut self) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickDeconstructImages(self.wand.as_ptr()) };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickdescribeimage>
@@ -782,7 +785,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn flatten_images(&mut self) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickFlattenImages(self.wand.as_ptr()) };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickflipimage>
@@ -845,7 +848,7 @@ impl<'a> MagickWand<'a> {
     pub fn fx_image(&mut self, expression: &str) -> Option<MagickWand<'_>> {
         let expression = str_to_c_string(expression);
         let wand = unsafe { MagickFxImage(self.wand.as_ptr(), expression.as_ptr()) };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickfximagechannel>
@@ -863,7 +866,7 @@ impl<'a> MagickWand<'a> {
         let wand = unsafe {
             MagickFxImageChannel(self.wand.as_ptr(), channel.into(), expression.as_ptr())
         };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgammaimage>
@@ -953,7 +956,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn get_image(&mut self) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickGetImage(self.wand.as_ptr()) };
-        Self::from_wand(wand)
+        unsafe { Self::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimageattribute>
@@ -2119,7 +2122,7 @@ impl<'a> MagickWand<'a> {
                 frame.as_ptr(),
             )
         };
-        MagickWand::from_wand(wand)
+        unsafe { MagickWand::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickmorphimages>
@@ -2145,7 +2148,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn mosaic_images(&mut self) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickMosaicImages(self.wand.as_ptr()) };
-        MagickWand::from_wand(wand)
+        unsafe { MagickWand::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickmotionblurimage>
@@ -2295,7 +2298,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn preview_images(&mut self, preview: PreviewType) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickPreviewImages(self.wand.as_ptr(), preview.into()) };
-        MagickWand::from_wand(wand)
+        unsafe { MagickWand::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickpreviousimage>
@@ -3627,7 +3630,7 @@ impl<'a> MagickWand<'a> {
         offset: c_long,
     ) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickSteganoImage(self.wand.as_ptr(), watermark_wand.wand(), offset) };
-        MagickWand::from_wand(wand)
+        unsafe { MagickWand::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickstereoimage>
@@ -3638,7 +3641,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn stereo_image(&mut self, offset_wand: &MagickWand<'_>) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickStereoImage(self.wand.as_ptr(), offset_wand.wand()) };
-        MagickWand::from_wand(wand)
+        unsafe { MagickWand::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickstripimage>
@@ -3671,7 +3674,7 @@ impl<'a> MagickWand<'a> {
     ///
     pub fn texture_image(&mut self, texture_wand: &MagickWand<'_>) -> Option<MagickWand<'_>> {
         let wand = unsafe { MagickTextureImage(self.wand.as_ptr(), texture_wand.wand()) };
-        MagickWand::from_wand(wand)
+        unsafe { MagickWand::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magickthresholdimage>
@@ -3739,7 +3742,7 @@ impl<'a> MagickWand<'a> {
         let geometry = str_to_c_string(geometry);
         let wand =
             unsafe { MagickTransformImage(self.wand.as_ptr(), crop.as_ptr(), geometry.as_ptr()) };
-        MagickWand::from_wand(wand)
+        unsafe { MagickWand::from_wand(wand) }
     }
 
     /// <http://www.graphicsmagick.org/wand/magick_wand.html#magicktransparentimage>

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -420,8 +420,7 @@ impl PixelWand {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{initialize, wand::PixelWand};
+    use crate::{initialize, types::PixelPacket, wand::PixelWand};
 
     fn new_pixel_wand() -> PixelWand {
         initialize();

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -421,7 +421,7 @@ impl PixelWand {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::initialize;
+    use crate::{initialize, wand::PixelWand};
 
     fn new_pixel_wand() -> PixelWand {
         initialize();

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -28,8 +28,11 @@ impl PixelWand {
         PixelWand { wand }
     }
 
+    /// # Safety
+    ///
+    ///  * `wand` - must points to either NULL, or a valid allocation.
     #[inline]
-    pub fn from_wand(wand: *mut graphicsmagick_sys::PixelWand) -> Option<PixelWand> {
+    pub unsafe fn from_wand(wand: *mut graphicsmagick_sys::PixelWand) -> Option<PixelWand> {
         NonNull::new(wand).map(|wand| PixelWand { wand })
     }
 

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -2,7 +2,10 @@
 //!
 //! <http://www.graphicsmagick.org/wand/pixel_wand.html>
 
-use crate::utils::{assert_initialized, str_to_c_string, MagickCString};
+use crate::{
+    types::*,
+    utils::{assert_initialized, str_to_c_string, MagickCString},
+};
 use graphicsmagick_sys::*;
 use std::{
     os::raw::{c_double, c_ulong},

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 /// Wrapper of `graphicsmagick_sys::PixelWand`.
+#[derive(Debug)]
 #[repr(transparent)]
 pub struct PixelWand {
     wand: NonNull<graphicsmagick_sys::PixelWand>,

--- a/graphicsmagick/src/wand/pixel.rs
+++ b/graphicsmagick/src/wand/pixel.rs
@@ -6,49 +6,44 @@ use crate::utils::{assert_initialized, str_to_c_string, MagickCString};
 use graphicsmagick_sys::*;
 use std::{
     os::raw::{c_double, c_ulong},
-    ptr::null_mut,
+    ptr::NonNull,
 };
 
 /// Wrapper of `graphicsmagick_sys::PixelWand`.
 #[repr(transparent)]
 pub struct PixelWand {
-    wand: *mut graphicsmagick_sys::PixelWand,
+    wand: NonNull<graphicsmagick_sys::PixelWand>,
 }
 
 impl PixelWand {
     pub fn new() -> Self {
         assert_initialized();
 
-        let wand = unsafe { NewPixelWand() };
-        assert_ne!(wand, null_mut(), "NewPixelWand return NULL");
+        let wand = NonNull::new(unsafe { NewPixelWand() }).expect("NewPixelWand return NULL");
 
         PixelWand { wand }
     }
 
     #[inline]
     pub fn from_wand(wand: *mut graphicsmagick_sys::PixelWand) -> Option<PixelWand> {
-        if wand.is_null() {
-            None
-        } else {
-            Some(PixelWand { wand })
-        }
+        NonNull::new(wand).map(|wand| PixelWand { wand })
     }
 
     #[inline]
     pub fn wand(&self) -> *const graphicsmagick_sys::PixelWand {
-        self.wand
+        self.wand.as_ptr() as *const _
     }
 
     #[inline]
     pub fn wand_mut(&mut self) -> *mut graphicsmagick_sys::PixelWand {
-        self.wand
+        self.wand.as_ptr()
     }
 }
 
 impl Drop for PixelWand {
     fn drop(&mut self) {
         unsafe {
-            DestroyPixelWand(self.wand);
+            DestroyPixelWand(self.wand.as_ptr());
         }
     }
 }
@@ -56,7 +51,8 @@ impl Drop for PixelWand {
 impl Clone for PixelWand {
     fn clone(&self) -> Self {
         PixelWand {
-            wand: unsafe { ClonePixelWand(self.wand) },
+            wand: NonNull::new(unsafe { ClonePixelWand(self.wand.as_ptr()) })
+                .expect("ClonePixelWand returns NULL"),
         }
     }
 }
@@ -73,7 +69,7 @@ impl PixelWand {
     /// PixelGetBlack() returns the normalized black color of the pixel wand.
     ///
     pub fn get_black(&self) -> c_double {
-        unsafe { PixelGetBlack(self.wand) }
+        unsafe { PixelGetBlack(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetblackquantum>
@@ -83,7 +79,7 @@ impl PixelWand {
     /// color is in the range of [0..MaxRGB]
     ///
     pub fn get_black_quantum(&self) -> Quantum {
-        unsafe { PixelGetBlackQuantum(self.wand) }
+        unsafe { PixelGetBlackQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetblue>
@@ -91,7 +87,7 @@ impl PixelWand {
     /// PixelGetBlue(const) returns the normalized blue color of the pixel wand.
     ///
     pub fn get_blue(&self) -> c_double {
-        unsafe { PixelGetBlue(self.wand) }
+        unsafe { PixelGetBlue(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetbluequantum>
@@ -101,7 +97,7 @@ impl PixelWand {
     /// color is in the range of [0..MaxRGB]
     ///
     pub fn get_blue_quantum(&self) -> Quantum {
-        unsafe { PixelGetBlueQuantum(self.wand) }
+        unsafe { PixelGetBlueQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetcolorasstring>
@@ -109,7 +105,7 @@ impl PixelWand {
     /// PixelGetColorAsString() gets the color of the pixel wand.
     ///
     pub fn get_color_as_string(&mut self) -> MagickCString {
-        unsafe { MagickCString::new(PixelGetColorAsString(self.wand)) }
+        unsafe { MagickCString::new(PixelGetColorAsString(self.wand.as_ptr())) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetcolorcount>
@@ -117,7 +113,7 @@ impl PixelWand {
     /// PixelGetColorCount() returns the color count associated with this color.
     ///
     pub fn get_color_count(&self) -> c_ulong {
-        unsafe { PixelGetColorCount(self.wand) }
+        unsafe { PixelGetColorCount(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetcyan>
@@ -125,7 +121,7 @@ impl PixelWand {
     /// PixelGetCyan() returns the normalized cyan color of the pixel wand.
     ///
     pub fn get_cyan(&self) -> c_double {
-        unsafe { PixelGetCyan(self.wand) }
+        unsafe { PixelGetCyan(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetcyanquantum>
@@ -135,7 +131,7 @@ impl PixelWand {
     /// is in the range of [0..MaxRGB]
     ///
     pub fn get_cyan_quantum(&self) -> Quantum {
-        unsafe { PixelGetCyanQuantum(self.wand) }
+        unsafe { PixelGetCyanQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetgreen>
@@ -143,7 +139,7 @@ impl PixelWand {
     /// PixelGetGreen(const ) returns the normalized green color of the pixel wand.
     ///
     pub fn get_green(&self) -> c_double {
-        unsafe { PixelGetGreen(self.wand) }
+        unsafe { PixelGetGreen(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetgreenquantum>
@@ -153,7 +149,7 @@ impl PixelWand {
     /// color is in the range of [0..MaxRGB]
     ///
     pub fn get_green_quantum(&self) -> Quantum {
-        unsafe { PixelGetGreenQuantum(self.wand) }
+        unsafe { PixelGetGreenQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetmagenta>
@@ -161,7 +157,7 @@ impl PixelWand {
     /// PixelGetMagenta() returns the normalized magenta color of the pixel wand.
     ///
     pub fn get_magenta(&self) -> c_double {
-        unsafe { PixelGetMagenta(self.wand) }
+        unsafe { PixelGetMagenta(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetmagentaquantum>
@@ -171,7 +167,7 @@ impl PixelWand {
     /// color is in the range of [0..MaxRGB]
     ///
     pub fn get_magenta_quantum(&self) -> Quantum {
-        unsafe { PixelGetMagentaQuantum(self.wand) }
+        unsafe { PixelGetMagentaQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetopacity>
@@ -181,7 +177,7 @@ impl PixelWand {
     /// wand.
     ///
     pub fn get_opacity(&self) -> c_double {
-        unsafe { PixelGetOpacity(self.wand) }
+        unsafe { PixelGetOpacity(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetopacityquantum>
@@ -191,7 +187,7 @@ impl PixelWand {
     /// The color is in the range of [0..MaxRGB]
     ///
     pub fn get_opacity_quantum(&self) -> Quantum {
-        unsafe { PixelGetOpacityQuantum(self.wand) }
+        unsafe { PixelGetOpacityQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetred>
@@ -199,7 +195,7 @@ impl PixelWand {
     /// PixelGetRed(const ) returns the normalized red color of the pixel wand.
     ///
     pub fn get_red(&self) -> c_double {
-        unsafe { PixelGetRed(self.wand) }
+        unsafe { PixelGetRed(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetredquantum>
@@ -209,7 +205,7 @@ impl PixelWand {
     /// color is in the range of [0..MaxRGB]
     ///
     pub fn get_red_quantum(&self) -> Quantum {
-        unsafe { PixelGetRedQuantum(self.wand) }
+        unsafe { PixelGetRedQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetyellow>
@@ -217,7 +213,7 @@ impl PixelWand {
     /// PixelGetYellow() returns the normalized yellow color of the pixel wand.
     ///
     pub fn get_yellow(&self) -> c_double {
-        unsafe { PixelGetYellow(self.wand) }
+        unsafe { PixelGetYellow(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelgetyellowquantum>
@@ -227,7 +223,7 @@ impl PixelWand {
     /// color is in the range of [0..MaxRGB]
     ///
     pub fn get_yellow_quantum(&self) -> Quantum {
-        unsafe { PixelGetYellowQuantum(self.wand) }
+        unsafe { PixelGetYellowQuantum(self.wand.as_ptr()) }
     }
 
     /// <http://www.graphicsmagick.org/wand/pixel_wand.html#pixelsetblack>
@@ -235,7 +231,7 @@ impl PixelWand {
     /// PixelSetBlack() sets the normalized black color of the pixel wand.
     ///
     pub fn set_black(&mut self, black: c_double) -> &mut Self {
-        unsafe { PixelSetBlack(self.wand, black) };
+        unsafe { PixelSetBlack(self.wand.as_ptr(), black) };
         self
     }
 
@@ -246,7 +242,7 @@ impl PixelWand {
     /// must be in the range of [0..MaxRGB]
     ///
     pub fn set_black_quantum(&mut self, black: Quantum) -> &mut Self {
-        unsafe { PixelSetBlackQuantum(self.wand, black) };
+        unsafe { PixelSetBlackQuantum(self.wand.as_ptr(), black) };
         self
     }
 
@@ -255,7 +251,7 @@ impl PixelWand {
     /// PixelSetBlue() sets the normalized blue color of the pixel wand.
     ///
     pub fn set_blue(&mut self, blue: c_double) -> &mut Self {
-        unsafe { PixelSetBlue(self.wand, blue) };
+        unsafe { PixelSetBlue(self.wand.as_ptr(), blue) };
         self
     }
 
@@ -266,7 +262,7 @@ impl PixelWand {
     /// be in the range of [0..MaxRGB]
     ///
     pub fn set_blue_quantum(&mut self, blue: Quantum) -> &mut Self {
-        unsafe { PixelSetBlueQuantum(self.wand, blue) };
+        unsafe { PixelSetBlueQuantum(self.wand.as_ptr(), blue) };
         self
     }
 
@@ -278,7 +274,7 @@ impl PixelWand {
     ///
     pub fn set_color(&mut self, color: &str) -> &mut Self {
         let color = str_to_c_string(color);
-        unsafe { PixelSetColor(self.wand, color.as_ptr()) };
+        unsafe { PixelSetColor(self.wand.as_ptr(), color.as_ptr()) };
         self
     }
 
@@ -287,7 +283,7 @@ impl PixelWand {
     /// PixelSetColorCount() sets the color count of the pixel wand.
     ///
     pub fn set_color_count(&mut self, count: c_ulong) -> &mut Self {
-        unsafe { PixelSetColorCount(self.wand, count) };
+        unsafe { PixelSetColorCount(self.wand.as_ptr(), count) };
         self
     }
 
@@ -296,7 +292,7 @@ impl PixelWand {
     /// PixelSetCyan() sets the normalized cyan color of the pixel wand.
     ///
     pub fn set_cyan(&mut self, cyan: c_double) -> &mut Self {
-        unsafe { PixelSetCyan(self.wand, cyan) };
+        unsafe { PixelSetCyan(self.wand.as_ptr(), cyan) };
         self
     }
 
@@ -307,7 +303,7 @@ impl PixelWand {
     /// be in the range of [0..MaxRGB]
     ///
     pub fn set_cyan_quantum(&mut self, cyan: Quantum) -> &mut Self {
-        unsafe { PixelSetCyanQuantum(self.wand, cyan) };
+        unsafe { PixelSetCyanQuantum(self.wand.as_ptr(), cyan) };
         self
     }
 
@@ -316,7 +312,7 @@ impl PixelWand {
     /// PixelSetGreen() sets the normalized green color of the pixel wand.
     ///
     pub fn set_green(&mut self, green: c_double) -> &mut Self {
-        unsafe { PixelSetGreen(self.wand, green) };
+        unsafe { PixelSetGreen(self.wand.as_ptr(), green) };
         self
     }
 
@@ -327,7 +323,7 @@ impl PixelWand {
     /// be in the range of [0..MaxRGB]
     ///
     pub fn set_green_quantum(&mut self, green: Quantum) -> &mut Self {
-        unsafe { PixelSetGreenQuantum(self.wand, green) };
+        unsafe { PixelSetGreenQuantum(self.wand.as_ptr(), green) };
         self
     }
 
@@ -336,7 +332,7 @@ impl PixelWand {
     /// PixelSetMagenta() sets the normalized magenta color of the pixel wand.
     ///
     pub fn set_magenta(&mut self, magenta: c_double) -> &mut Self {
-        unsafe { PixelSetMagenta(self.wand, magenta) };
+        unsafe { PixelSetMagenta(self.wand.as_ptr(), magenta) };
         self
     }
 
@@ -347,7 +343,7 @@ impl PixelWand {
     /// color must be in the range of [0..MaxRGB]
     ///
     pub fn set_magenta_quantum(&mut self, magenta: Quantum) -> &mut Self {
-        unsafe { PixelSetMagentaQuantum(self.wand, magenta) };
+        unsafe { PixelSetMagentaQuantum(self.wand.as_ptr(), magenta) };
         self
     }
 
@@ -356,7 +352,7 @@ impl PixelWand {
     /// PixelSetOpacity() sets the normalized opacity color of the pixel wand.
     ///
     pub fn set_opacity(&mut self, opacity: c_double) -> &mut Self {
-        unsafe { PixelSetOpacity(self.wand, opacity) };
+        unsafe { PixelSetOpacity(self.wand.as_ptr(), opacity) };
         self
     }
 
@@ -367,7 +363,7 @@ impl PixelWand {
     /// color must be in the range of [0..MaxRGB]
     ///
     pub fn set_opacity_quantum(&mut self, opacity: Quantum) -> &mut Self {
-        unsafe { PixelSetOpacityQuantum(self.wand, opacity) };
+        unsafe { PixelSetOpacityQuantum(self.wand.as_ptr(), opacity) };
         self
     }
 
@@ -376,7 +372,7 @@ impl PixelWand {
     /// PixelSetQuantumColor() sets the color of the pixel wand.
     ///
     pub fn set_quantum_color(&mut self, color: &mut PixelPacket) -> &mut Self {
-        unsafe { PixelSetQuantumColor(self.wand, color as *mut PixelPacket) };
+        unsafe { PixelSetQuantumColor(self.wand.as_ptr(), color as *mut PixelPacket) };
         self
     }
 
@@ -385,7 +381,7 @@ impl PixelWand {
     /// PixelSetRed() sets the normalized red color of the pixel wand.
     ///
     pub fn set_red(&mut self, red: c_double) -> &mut Self {
-        unsafe { PixelSetRed(self.wand, red) };
+        unsafe { PixelSetRed(self.wand.as_ptr(), red) };
         self
     }
 
@@ -396,7 +392,7 @@ impl PixelWand {
     /// be in the range of [0..MaxRGB]
     ///
     pub fn set_red_quantum(&mut self, red: Quantum) -> &mut Self {
-        unsafe { PixelSetRedQuantum(self.wand, red) };
+        unsafe { PixelSetRedQuantum(self.wand.as_ptr(), red) };
         self
     }
 
@@ -405,7 +401,7 @@ impl PixelWand {
     /// PixelSetYellow() sets the normalized yellow color of the pixel wand.
     ///
     pub fn set_yellow(&mut self, yellow: c_double) -> &mut Self {
-        unsafe { PixelSetYellow(self.wand, yellow) };
+        unsafe { PixelSetYellow(self.wand.as_ptr(), yellow) };
         self
     }
 
@@ -416,7 +412,7 @@ impl PixelWand {
     /// must be in the range of [0..MaxRGB]
     ///
     pub fn set_yellow_quantum(&mut self, yellow: Quantum) -> &mut Self {
-        unsafe { PixelSetYellowQuantum(self.wand, yellow) };
+        unsafe { PixelSetYellowQuantum(self.wand.as_ptr(), yellow) };
         self
     }
 }


### PR DESCRIPTION
 - [Change DrawingWand::wand to use NonNull](https://github.com/jmjoy/graphicsmagick-rs/commit/6bd9dcbbf6b6222097dbcb56d6a3bbeec5428252)
 - [Mark DrawingWand to be repr(transparent)](https://github.com/jmjoy/graphicsmagick-rs/commit/255c3010df7987ef6e2d448799aed95d2944d91e)
 - [Derive Debug on DrawingWand](https://github.com/jmjoy/graphicsmagick-rs/commit/d3c0a71b2ae8a43f818a3526fc3993a5dac3b4ba)
 - [Change PixelWand::wand to use NonNull](https://github.com/jmjoy/graphicsmagick-rs/commit/277c2cad674c9a0fa9657f2d39bd8dcca1a5ea7c)
 - [Derive Debug for PixelWand](https://github.com/jmjoy/graphicsmagick-rs/commit/65e54c3ac73abb23fcdd8303f06bbf9953ad3ee6)
 - [Change MagickWand::wand to use NonNull](https://github.com/jmjoy/graphicsmagick-rs/commit/c58ef0be45a34c71955e5b41ca784967099d32a8)
 - [Mark MagickWand as repr(transparent)](https://github.com/jmjoy/graphicsmagick-rs/commit/08f5f4cbfde4dd9d4f225a8bdc3e6c2a974ba681)
 - [Derive Debug for MagickWand](https://github.com/jmjoy/graphicsmagick-rs/commit/cf053deba8e37332e26237394ed9f8c748c7707a)
 - [Mark MagickWand::from_wand as unsafe](https://github.com/jmjoy/graphicsmagick-rs/commit/5f355556b6261c0be426c71018d62575579750cf)
 - [Re-export AffineMatrix and PointInfo in mod types](https://github.com/jmjoy/graphicsmagick-rs/commit/646e6587a8224a3cf8accb29c8d2b28d34c7c9ec)
 - [Re-export PixelPacket in mod types](https://github.com/jmjoy/graphicsmagick-rs/commit/bbee823faac7a8dce07990876d134f5b5acdc5dd)
 - [Re-export Quantum in mod types](https://github.com/jmjoy/graphicsmagick-rs/commit/36010a18cbe53895a88084186626ce4c73124f4b)
 - [Mark PixelWand::from_wand as unsafe](https://github.com/jmjoy/graphicsmagick-rs/commit/272d19587d1e9727929d244542d9371f28a9d979)
 - Improvement to `MagickWand::get_error`: Preseve as much error info as possible and use RAII to ensure memory get freed on unwinding
 - [Mark enum Error as non_exhaustive](https://github.com/jmjoy/graphicsmagick-rs/commit/a3e53e3bc7120f07d461781904c7cf562aaddb4a)